### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,10 +48,10 @@ jobs:
       - name: 'Generate suffixes for comment'
         id: names
         run: |
-          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
-          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
-          echo "default_target=${DEFAULT_TARGET}" >> $GITHUB_OUTPUT
-          echo "suffix=${SUFFIX}" >> $GITHUB_OUTPUT
+          echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "default_target=${DEFAULT_TARGET}" >> "$GITHUB_OUTPUT"
+          echo "suffix=${SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: 'Bundle scripts'
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,10 +48,10 @@ jobs:
       - name: 'Generate suffixes for comment'
         id: names
         run: |
-          echo "::set-output name=branch_name::${BRANCH_NAME}"
-          echo "::set-output name=commit_sha::${COMMIT_SHA}"
-          echo "::set-output name=default_target::${DEFAULT_TARGET}"
-          echo "::set-output name=suffix::${SUFFIX}"
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+          echo "default_target=${DEFAULT_TARGET}" >> $GITHUB_OUTPUT
+          echo "suffix=${SUFFIX}" >> $GITHUB_OUTPUT
 
       - name: 'Bundle scripts'
         if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/check_submodules.yml
+++ b/.github/workflows/check_submodules.yml
@@ -35,12 +35,12 @@ jobs:
           BRANCHES=$(git branch -r --contains "$SUBMODULE_HASH");
           COMMITS_IN_BRANCH="$(git rev-list --count dev)";
           if [ $COMMITS_IN_BRANCH -lt $SUB_COMMITS_MIN ]; then
-            echo "fails=error" >> $GITHUB_OUTPUT;
+            echo "fails=error" >> "$GITHUB_OUTPUT";
             echo "::error::Error: Too low commits in $SUB_BRANCH of submodule $SUB_PATH: $COMMITS_IN_BRANCH(expected $SUB_COMMITS_MIN+)";
             exit 1;
           fi
           if ! grep -q "/$SUB_BRANCH" <<< "$BRANCHES"; then
-            echo "fails=error" >> $GITHUB_OUTPUT;
+            echo "fails=error" >> "$GITHUB_OUTPUT";
             echo "::error::Error: Submodule $SUB_PATH is not on branch $SUB_BRANCH";
             exit 1;
           fi

--- a/.github/workflows/check_submodules.yml
+++ b/.github/workflows/check_submodules.yml
@@ -35,12 +35,12 @@ jobs:
           BRANCHES=$(git branch -r --contains "$SUBMODULE_HASH");
           COMMITS_IN_BRANCH="$(git rev-list --count dev)";
           if [ $COMMITS_IN_BRANCH -lt $SUB_COMMITS_MIN ]; then
-            echo "::set-output name=fails::error";
+            echo "fails=error" >> $GITHUB_OUTPUT;
             echo "::error::Error: Too low commits in $SUB_BRANCH of submodule $SUB_PATH: $COMMITS_IN_BRANCH(expected $SUB_COMMITS_MIN+)";
             exit 1;
           fi
           if ! grep -q "/$SUB_BRANCH" <<< "$BRANCHES"; then
-            echo "::set-output name=fails::error";
+            echo "fails=error" >> $GITHUB_OUTPUT;
             echo "::error::Error: Submodule $SUB_PATH is not on branch $SUB_BRANCH";
             exit 1;
           fi

--- a/.github/workflows/pvs_studio.yml
+++ b/.github/workflows/pvs_studio.yml
@@ -45,10 +45,10 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork && github.event.pull_request }}
         id: names
         run: |
-          echo "::set-output name=branch_name::${BRANCH_NAME}"
-          echo "::set-output name=commit_sha::${COMMIT_SHA}"
-          echo "::set-output name=default_target::${DEFAULT_TARGET}"
-          echo "::set-output name=suffix::${SUFFIX}"
+          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
+          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
+          echo "default_target=${DEFAULT_TARGET}" >> $GITHUB_OUTPUT
+          echo "suffix=${SUFFIX}" >> $GITHUB_OUTPUT
 
       - name: 'Make reports directory'
         run: |

--- a/.github/workflows/pvs_studio.yml
+++ b/.github/workflows/pvs_studio.yml
@@ -45,10 +45,10 @@ jobs:
         if: ${{ !github.event.pull_request.head.repo.fork && github.event.pull_request }}
         id: names
         run: |
-          echo "branch_name=${BRANCH_NAME}" >> $GITHUB_OUTPUT
-          echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
-          echo "default_target=${DEFAULT_TARGET}" >> $GITHUB_OUTPUT
-          echo "suffix=${SUFFIX}" >> $GITHUB_OUTPUT
+          echo "branch_name=${BRANCH_NAME}" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "default_target=${DEFAULT_TARGET}" >> "$GITHUB_OUTPUT"
+          echo "suffix=${SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: 'Make reports directory'
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


